### PR TITLE
3.6/bugfixes

### DIFF
--- a/front/processmaker.form.php
+++ b/front/processmaker.form.php
@@ -85,7 +85,7 @@ switch ($_POST["action"]) {
       } else if (isset($_POST['reassign'])) {
          // here we should re-assign the current task to $_POST['users_id_recipient']
          //$GLPINewPMUserId = PluginProcessmakerUser::getPMUserId( $_POST['users_id_recipient'] );
-         if ($_POST['users_id'] != $_POST['users_id_recipient']) { // normally should be different as of the dropdown prevents already used
+         if ($_POST['users_id'] != $_POST['users_id_recipient'] && $_POST['users_id_recipient'] != 0) { // normally should be different as of the dropdown prevents already used
             $locCase = new PluginProcessmakerCase;
             $locCase->getFromDB($_POST['cases_id']);
 
@@ -100,7 +100,13 @@ switch ($_POST["action"]) {
                Session::addMessageAfterRedirect(__('Error re-assigning task: ', 'processmaker').$pmResponse->message, true, ERROR);
             }
          } else {
-            Session::addMessageAfterRedirect(__('Task already assigned to this person!', 'processmaker'), true, ERROR);
+            if ($_POST['users_id_recipient'] == 0) {
+               Session::addMessageAfterRedirect(__('Can\'t un-assign Task!', 'processmaker'), true, ERROR);
+            } else {
+               if ($_POST['users_id'] === $_POST['users_id_recipient'] ) { // normally should be different as of the dropdown prevents already used
+                  Session::addMessageAfterRedirect(__('Task already assigned to this person!', 'processmaker'), true, ERROR);
+               }
+            }
          }
          //} else if (isset($_POST['delete'])) {
          //   // delete case from case table, this will also delete the tasks

--- a/inc/case.class.php
+++ b/inc/case.class.php
@@ -232,10 +232,13 @@ class PluginProcessmakerCase extends CommonDBTM {
     */
    function reassignCase($delIndex, $taskGuid, $delThread, $users_id_source, $users_id_target) {
       global $PM_SOAP;
-      $users_guid_source = PluginProcessmakerUser::getPMUserId($users_id_source);
+      $users_guid_source = ''; // by default
+      if ($users_id_source !== 0) { // when task is not 'to be claimed'
+         $users_guid_source = PluginProcessmakerUser::getPMUserId($users_id_source);
+      }
       $users_guid_target = PluginProcessmakerUser::getPMUserId($users_id_target);
       $pmResponse = $PM_SOAP->reassignCase($this->fields['case_guid'], $delIndex, $users_guid_source, $users_guid_target);
-      // now should managed GLPI Tasks previously assigned to the $users_guid_source
+      // now should manage GLPI Tasks previously assigned to the $users_guid_source
       if ($pmResponse->status_code == 0) {
          // we need to change the delindex of the glpi task and the assigned tech to prevent creation of new tasks
          // we need the delindex of the current glpi task, and the delindex of the new one
@@ -279,7 +282,11 @@ class PluginProcessmakerCase extends CommonDBTM {
          PluginProcessmakerProcessmaker::addWatcher( $itilobject_itemtype, $glpi_task->fields[ $foreignkey ], $newTech );
 
          $donotif = PluginProcessmakerNotificationTargetProcessmaker::saveNotificationState(false); // do not send notification yet
-         $glpi_task->update( ['id' => $glpi_task->getID(), $foreignkey => $glpi_task->fields[$foreignkey], 'users_id_tech' => $newTech, 'update' => true] );
+         $glpi_task->update( ['id'              => $glpi_task->getID(),
+                              $foreignkey       => $glpi_task->fields[$foreignkey],
+                              'users_id_tech'   => $newTech,
+                              'groups_id_tech'  => 0,
+                              'update'          => true] );
          PluginProcessmakerNotificationTargetProcessmaker::restoreNotificationState($donotif);
 
          // Notification management

--- a/inc/case.class.php
+++ b/inc/case.class.php
@@ -918,6 +918,7 @@ class PluginProcessmakerCase extends CommonDBTM {
          $res = $DB->update('glpi_'.$this->fields['itemtype'].'tasks', [
                   'state'           => 0,
                   'users_id_tech'   => 0,
+                  'groups_id_tech'  => 0,
                   'begin'           => null,
                   'end'             => null
                   ], [

--- a/inc/notificationtargettask.class.php
+++ b/inc/notificationtargettask.class.php
@@ -105,6 +105,9 @@ class PluginProcessmakerNotificationTargetTask extends PluginProcessmakerNotific
       // task information
       $taskobj = $this->obj;
 
+      // del index
+      $this->data['##task.delindex##'] = $taskobj->fields['del_index'];
+
       // is private?
       $this->data['##task.isprivate##'] = Dropdown::getYesNo(false);
       if ($taskobj->maybePrivate()) {
@@ -175,7 +178,8 @@ class PluginProcessmakerNotificationTargetTask extends PluginProcessmakerNotific
                'task.end'                => __('End date'),
                'task.status'             => __('Status'),
                'task.lastupdater'        => __('Last updater'),
-               'task.update'             => __('Last update')
+               'task.update'             => __('Last update'),
+               'task.delindex'           => __('Delegation index')
              ];
       foreach ($tags as $tag => $label) {
          $elt= ['tag'   => $tag,

--- a/inc/processmaker.class.php
+++ b/inc/processmaker.class.php
@@ -2913,6 +2913,7 @@ class PluginProcessmakerProcessmaker extends CommonDBTM {
       $casevariables = ["GLPI_ITEM_TASK_CONTENT",
                         "GLPI_ITEM_APPEND_TO_TASK",
                         "GLPI_NEXT_GROUP_TO_BE_ASSIGNED",
+                        "GLPI_ITEM_TASK_GROUP",
                         "GLPI_ITEM_TITLE",
                         "GLPI_TICKET_FOLLOWUP_CONTENT",
                         "GLPI_ITEM_FOLLOWUP_CONTENT",
@@ -2970,6 +2971,9 @@ class PluginProcessmakerProcessmaker extends CommonDBTM {
       $groupId = 0;
       if (array_key_exists( 'GLPI_NEXT_GROUP_TO_BE_ASSIGNED', $casevariablevalues )) {
          $groupId = $casevariablevalues[ 'GLPI_NEXT_GROUP_TO_BE_ASSIGNED' ];
+      }
+      if (array_key_exists( 'GLPI_ITEM_TASK_GROUP', $casevariablevalues )) {
+         $groupId = $casevariablevalues[ 'GLPI_ITEM_TASK_GROUP' ];
       }
 
       $taskStartDate = '';
@@ -3237,16 +3241,7 @@ class PluginProcessmakerProcessmaker extends CommonDBTM {
                }
             }
 
-      // send email if requested
-      if (is_array($sendemail)) {
-         NotificationEvent::raiseEvent('send_email',
-                                       $myCase,
-                                       ['glpi_send_email' => $sendemail,
-                                        'case'            => $myCase
-                                       ]);
-      }
-
-   }
+         }
 
       } else {
          // must check if current case is a sub-process, and if it has ended, then must reflect parent case into the current item.
@@ -3278,7 +3273,7 @@ class PluginProcessmakerProcessmaker extends CommonDBTM {
                                             $parentCaseInfo,
                                             $open_task->delIndex,
                                             PluginProcessmakerUser::getGLPIUserId($open_task->userId),
-                                            0,
+                                            $groupId,
                                             $open_task->taskId,
                                             $open_task->delThread,
                                             [ 'txtTaskContent' => $txtTaskContent,
@@ -3289,7 +3284,7 @@ class PluginProcessmakerProcessmaker extends CommonDBTM {
 
                      // if end date was specified, then must change due date of the PM task
                      if ($taskEndDate != '') {
-                        $PM_DB->update('APP_DELEGATION', ['DEL_TASK_DUE_DATE' => $taskEndDate], ['AND' => ['APP_UID' => $sub_caseInfo->caseId, 'DEL_INDEX' => $open_task->delIndex]]);
+                        $PM_DB->update('APP_DELEGATION', ['DEL_TASK_DUE_DATE' => $taskEndDate], ['AND' => ['APP_UID' => $parentCaseInfo->caseId, 'DEL_INDEX' => $open_task->delIndex]]);
                            //$PM_DB->query( "UPDATE APP_DELEGATION SET DEL_TASK_DUE_DATE='$taskEndDate' WHERE APP_UID='".$sub_caseInfo->caseId."' AND DEL_INDEX=".$open_task->delIndex);
                      }
                   }

--- a/inc/processmaker.class.php
+++ b/inc/processmaker.class.php
@@ -1743,11 +1743,12 @@ class PluginProcessmakerProcessmaker extends CommonDBTM {
       if ($techId == 0) { // then we must look-up DB to get the group that will be assigned to the task
          $groupname='';
          if ($groupId == 0) {
+            // TU_RELATION=2 is groups and TU_TYPE=1 means normal (= not adhoc)
             $res = $PM_DB->request([
                            'SELECT'       => 'CONTENT.CON_VALUE',
                            'FROM'         => 'TASK_USER',
                            'INNER JOIN'   => ['CONTENT' => ['AND' => ['FKEY' => ['CONTENT' => 'CON_ID', 'TASK_USER' => 'USR_UID'], ['CONTENT' => 'CON_CATEGORY', 'GRP_TITLE'], ['CONTENT' => 'CON_LANG', 'en']]]],
-                           'WHERE'        => ['AND' => ['TASK_USER.TAS_UID' => $pmTaskId, 'TASK_USER.TU_RELATION' => 2]],
+                           'WHERE'        => ['AND' => ['TASK_USER.TAS_UID' => $pmTaskId, 'TASK_USER.TU_RELATION' => 2, 'TASK_USER.TU_TYPE' => 1]],
                            'LIMIT'        => 1
                         ]);
             //$query = "SELECT CONTENT.CON_VALUE FROM TASK_USER

--- a/inc/profile.class.php
+++ b/inc/profile.class.php
@@ -20,7 +20,7 @@ class PluginProcessmakerProfile extends CommonDBTM {
                    ['itemtype' => 'PluginProcessmakerConfig',
                         'label'    =>  __('Cases', 'processmaker'),
                         'field'    => 'plugin_processmaker_case',
-                        'rights' => [READ => __('Read'), CANCEL => __('Cancel', 'processmaker'), DELETE  => __('Delete')]]
+                        'rights' => [READ => __('Read'), CANCEL => __('Cancel', 'processmaker'), DELETE  => __('Delete'), ADHOC_REASSIGN => __('Ad Hoc user re-assign', 'processmaker')]]
                    ];
 
       return $rights;
@@ -69,7 +69,7 @@ class PluginProcessmakerProfile extends CommonDBTM {
      * @param mixed $ID
      */
    static function createAdminAccess($ID) {
-      self::addDefaultProfileInfos($ID, ['plugin_processmaker_config' => READ + UPDATE, 'plugin_processmaker_case' => READ + DELETE + CANCEL], true);
+      self::addDefaultProfileInfos($ID, ['plugin_processmaker_config' => READ + UPDATE, 'plugin_processmaker_case' => READ + DELETE + CANCEL + ADHOC_REASSIGN], true);
    }
 
     /**

--- a/inc/task.class.php
+++ b/inc/task.class.php
@@ -377,8 +377,8 @@ class PluginProcessmakerTask extends CommonITILTask
       }
 
       if (isset($currentUser)) {
-         if ($currentUser->userId && $task[$tabnum]['del_index']) {
-            // to load users for task re-assign only when task is not to be 'claimed' and if task is not a sub-case
+         if (/*$currentUser->userId &&*/ $task[$tabnum]['del_index']) {
+            // to load users for task re-assign only when task is not a sub-case
 
             echo "<div class='tab_bg_2' id='divUsers-".$currentUser->delIndex."'><div class='loadingindicator'>".__('Loading...')."</div></div>";
             echo "<script>$('#divUsers-{$task[$tabnum]['del_index']}').load( '".$CFG_GLPI["root_doc"]."/plugins/processmaker/ajax/task_users.php?cases_id="
@@ -392,7 +392,19 @@ class PluginProcessmakerTask extends CommonITILTask
                      ."&taskGuid="
                      .$currentUser->taskId
                      ."&delIndex={$task[$tabnum]['del_index']}&delThread={$currentUser->delThread}&rand=$rand' ); </script>";
-         } else {
+         //} else {
+         //   // manages the claim
+         //   // current task is to be claimed
+         //   // get the assigned group to the item task
+         //   $itemtask = $dbu->getItemForItemtype( $task[$tabnum]['itemtype'] );
+         //   $itemtask->getFromDB( $task[$tabnum]['items_id'] );
+         //   // check if this group can be found in the current user's groups
+         //   if (!isset($_SESSION['glpigroups']) || !in_array( $itemtask->fields['groups_id_tech'], $_SESSION['glpigroups'] )) {
+         //      $hide_claim_button=true;
+         //   }
+         }
+
+         if (!$currentUser->userId || !$task[$tabnum]['del_index']) {
             // manages the claim
             // current task is to be claimed
             // get the assigned group to the item task

--- a/processmaker.xml
+++ b/processmaker.xml
@@ -29,15 +29,15 @@
        <compatibility>9.1</compatibility>
      </version>
      <version>
-       <num>3.4.12</num>
+       <num>3.4.13</num>
        <compatibility>9.2</compatibility>
      </version>
       <version>
-         <num>3.5.3</num>
+         <num>3.5.4</num>
          <compatibility>9.3</compatibility>
       </version>
      <version>
-       <num>3.6.3</num>
+       <num>3.6.4</num>
        <compatibility>9.4</compatibility>
      </version>
    </versions>

--- a/processmaker.xml
+++ b/processmaker.xml
@@ -29,15 +29,15 @@
        <compatibility>9.1</compatibility>
      </version>
      <version>
-       <num>3.4.13</num>
+       <num>3.4.14</num>
        <compatibility>9.2</compatibility>
      </version>
       <version>
-         <num>3.5.4</num>
+         <num>3.5.5</num>
          <compatibility>9.3</compatibility>
       </version>
      <version>
-       <num>3.6.4</num>
+       <num>3.6.5</num>
        <compatibility>9.4</compatibility>
      </version>
    </versions>

--- a/setup.php
+++ b/setup.php
@@ -1,6 +1,6 @@
 <?php
 
-define('PROCESSMAKER_VERSION', '3.6.4');
+define('PROCESSMAKER_VERSION', '3.6.5');
 
 // used for case cancellation
 define("CANCEL", 256);

--- a/setup.php
+++ b/setup.php
@@ -1,8 +1,11 @@
 <?php
 
+define('PROCESSMAKER_VERSION', '3.6.4');
+
 // used for case cancellation
 define("CANCEL", 256);
-define('PROCESSMAKER_VERSION', '3.6.3');
+// used for ad-hoc user re-assign
+define("ADHOC_REASSIGN", 512);
 
 // Init the hooks of the plugins -Needed
 function plugin_init_processmaker() {


### PR DESCRIPTION
Added adhoc users re-assign rights
Added possibility to assign a task to an adhoc user
Added task del_index tag to notification template
Added missing GLPI_ITEM_TASK_GROUP
Deleted extra-email sending
Fixed issue on users for re-assignment
Added a filter on TASK_USER.TU_TYPE to be sure that it searches for normal assignment (not adhoc)
Added default groups_id_tech (set to 0) when clearing a task
Set new version to 3.6.5
