### PR TITLE
Automatic reminders, New case within timeline and dynaform use within timeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ version 4.0.x is compatible with GLPI 9.5 and needs ProcessMaker 3.3.0-RE-1.x (h
 
 version 4.3.x is compatible with GLPI 9.5 and needs ProcessMaker 3.3.0-RE-1.13 (https://github.com/tomolimo/processmaker-server/releases/latest)
 
-version 4.4.x is compatible with GLPI 9.5 and needs ProcessMaker 3.3.0-RE-2.0 (https://github.com/tomolimo/processmaker-server/releases/latest)
+version 4.6.x is compatible with GLPI 9.5 and needs ProcessMaker 3.3.0-RE-2.x (https://github.com/tomolimo/processmaker-server/releases/latest)
 
-version 5.0.x is compatible with GLPI 10.0 and needs ProcessMaker 3.3.0-RE-2.0 (https://github.com/tomolimo/processmaker-server/releases/latest)
+version 5.1.x is compatible with GLPI 10.0 and needs ProcessMaker 3.3.0-RE-2.0 (https://github.com/tomolimo/processmaker-server/releases/latest)
 
-This plugin can run classic (ProcessMaker server v2) and BPMN (ProcessMaker server v3 and later) processes
+This plugin can run classic (ProcessMaker server v2) and BPMN (ProcessMaker server v3) processes
 

--- a/ajax/asynchronousdatas.php
+++ b/ajax/asynchronousdatas.php
@@ -2,7 +2,7 @@
 /*
 -------------------------------------------------------------------------
 ProcessMaker plugin for GLPI
-Copyright (C) 2014-2023 by Raynet SAS a company of A.Raymond Network.
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
 
 https://www.araymond.com/
 -------------------------------------------------------------------------
@@ -53,11 +53,22 @@ if (isset( $_SERVER['REQUEST_METHOD'] )  && $_SERVER['REQUEST_METHOD']=='OPTIONS
             $datas = json_decode($request_body, true);
 
             $asyncdata = new PluginProcessmakerCrontaskaction;
-            if (isset($datas['id']) && $asyncdata->getFromDB( $datas['id'] ) && $asyncdata->fields['state'] == PluginProcessmakerCrontaskaction::WAITING_DATA) {
+
+            $ID = 0;
+            if (isset($_REQUEST['id'])) {
+               $ID = $_REQUEST['id'];
+            }
+            if (isset($datas['id'])) {
+                $ID = $datas['id'];
+            }
+            if ($ID && $asyncdata->getFromDB($ID) && $asyncdata->fields['state'] == PluginProcessmakerCrontaskaction::WAITING_DATA) {
                $initialdatas = json_decode($asyncdata->fields['formdata'], true);
-               $initialdatas['form'] = array_merge( $initialdatas['form'], $datas['form'] );
+               if (isset($datas['form'])) {
+                   $datas = $datas['form'];
+               }
+               $initialdatas['form'] = array_merge( $initialdatas['form'], $datas );
                $formdata = json_encode($initialdatas, JSON_HEX_APOS | JSON_HEX_QUOT | JSON_UNESCAPED_UNICODE);
-               $asyncdata->update( [ 'id' => $datas['id'], 'state' => PluginProcessmakerCrontaskaction::DATA_READY, 'formdata' => $formdata ] );
+               $asyncdata->update( [ 'id' => $ID, 'state' => PluginProcessmakerCrontaskaction::DATA_READY, 'formdata' => $formdata ] );
                $ret = [ 'code' => '0', 'message' => 'Done' ];
             } else {
                $ret = [ 'code' => '2', 'message' => 'Case is not existing, or state is not WAITING_DATA' ];

--- a/ajax/case.php
+++ b/ajax/case.php
@@ -1,0 +1,52 @@
+<?php
+/*
+-------------------------------------------------------------------------
+ProcessMaker plugin for GLPI
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
+
+https://www.araymond.com/
+-------------------------------------------------------------------------
+
+LICENSE
+
+This file is part of ProcessMaker plugin for GLPI.
+
+This file is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This plugin is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this plugin. If not, see <http://www.gnu.org/licenses/>.
+--------------------------------------------------------------------------
+ */
+
+use Glpi\Application\View\TemplateRenderer;
+include ("../../../inc/includes.php");
+$item = new $_REQUEST['itemtype'];
+$item->getFromDB($_REQUEST['items_id']);
+$countProcesses = [];
+$cases = PluginProcessmakerCase::getAllCases($_REQUEST['itemtype'], $_REQUEST['items_id'], $countProcesses);
+echo "<div class='row'>";
+echo "<div class='col-auto order-last d-none d-md-block'>";
+TemplateRenderer::getInstance()->display(
+                'components\user\picture.html.twig',
+                [
+                    'users_id' => Session::getLoginUserID(),
+                ]
+            );
+echo "</div>";
+echo "<div class='col'>";
+echo "<div class='row timeline-content t-right card mt-4' style='border: 1px solid rgb(65, 133, 244);'>";
+echo "<div class='card-body'>";
+echo "<div class='clearfix'>";
+echo "<button class='btn btn-sm btn-ghost-secondary float-end mb-1 close-new-case-form collapsed' data-bs-toggle='collapse' data-bs-target='#new-CaseForm-block' aria-expanded='false'>";
+echo "<i class='fa-lg ti ti-x'></i></button></div>";
+echo "<div class='newCaseContent'>";
+PluginProcessmakerCase::showAddFormForItem($item, rand(), $countProcesses, true);
+echo "</div></div></div></div></div>";

--- a/ajax/dropdownProcesses.php
+++ b/ajax/dropdownProcesses.php
@@ -2,7 +2,7 @@
 /*
 -------------------------------------------------------------------------
 ProcessMaker plugin for GLPI
-Copyright (C) 2014-2023 by Raynet SAS a company of A.Raymond Network.
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
 
 https://www.araymond.com/
 -------------------------------------------------------------------------

--- a/ajax/dropdownTaskcategories.php
+++ b/ajax/dropdownTaskcategories.php
@@ -2,7 +2,7 @@
 /*
 -------------------------------------------------------------------------
 ProcessMaker plugin for GLPI
-Copyright (C) 2014-2023 by Raynet SAS a company of A.Raymond Network.
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
 
 https://www.araymond.com/
 -------------------------------------------------------------------------

--- a/ajax/dropdownTicketCategories.php
+++ b/ajax/dropdownTicketCategories.php
@@ -2,7 +2,7 @@
 /*
 -------------------------------------------------------------------------
 ProcessMaker plugin for GLPI
-Copyright (C) 2014-2023 by Raynet SAS a company of A.Raymond Network.
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
 
 https://www.araymond.com/
 -------------------------------------------------------------------------

--- a/ajax/dropdownUsers.php
+++ b/ajax/dropdownUsers.php
@@ -2,7 +2,7 @@
 /*
 -------------------------------------------------------------------------
 ProcessMaker plugin for GLPI
-Copyright (C) 2014-2023 by Raynet SAS a company of A.Raymond Network.
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
 
 https://www.araymond.com/
 -------------------------------------------------------------------------
@@ -58,8 +58,7 @@ if (!isset($_REQUEST['all'])) {
 }
 
 $used = [];
-
-if (isset($_REQUEST['used'])) {
+if (isset($_REQUEST['used']) && is_array($_REQUEST['used'])) {
    $used = $_REQUEST['used'];
 }
 
@@ -98,7 +97,7 @@ $users = [];
 $count = 0;
 foreach ($res as $data) {
    $users[$data["id"]] = $dbu->formatUserName($data["id"], $data["name"], $data["realname"],
-                                          $data["firstname"], 0);
+                                          $data["firstname"], 0) . " (" . $data["name"] . ")";
    $logins[$data["id"]] = $data["name"];
 }
 

--- a/ajax/selfservicedrafts.php
+++ b/ajax/selfservicedrafts.php
@@ -2,7 +2,7 @@
 /*
 -------------------------------------------------------------------------
 ProcessMaker plugin for GLPI
-Copyright (C) 2014-2023 by Raynet SAS a company of A.Raymond Network.
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
 
 https://www.araymond.com/
 -------------------------------------------------------------------------

--- a/ajax/task.php
+++ b/ajax/task.php
@@ -25,14 +25,10 @@ You should have received a copy of the GNU General Public License
 along with this plugin. If not, see <http://www.gnu.org/licenses/>.
 --------------------------------------------------------------------------
  */
-/**
- * selfservicedraft short summary.
- *
- * selfservicedraft description.
- *
- * @version 1.0
- * @author morono
- */
-class PluginProcessmakerSelfservicedraft extends CommonDBTM {
 
+include ("../../../inc/includes.php");
+if( isset($_REQUEST) && !empty($_REQUEST)) {
+    $Case = new PluginProcessmakerCase;
+    $Case->getFromDB($_REQUEST['cases_id']);
+    PluginProcessmakerTask::displayTabContentForItem($Case, $_REQUEST['tabnum']);    
 }

--- a/ajax/task_users.php
+++ b/ajax/task_users.php
@@ -2,7 +2,7 @@
 /*
 -------------------------------------------------------------------------
 ProcessMaker plugin for GLPI
-Copyright (C) 2014-2023 by Raynet SAS a company of A.Raymond Network.
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
 
 https://www.araymond.com/
 -------------------------------------------------------------------------
@@ -59,10 +59,15 @@ $PM_SOAP = new PluginProcessmakerProcessmaker;
 $PM_DB = new PluginProcessmakerDB;
 
 echo "<form style='margin-bottom: 0px' name='processmaker_form_task$rand-".$_REQUEST['delIndex']."' id='processmaker_form_task$rand-".$_REQUEST['delIndex']."' method='post' action='".Toolbox::getItemTypeFormURL("PluginProcessmakerProcessmaker")."'>";
-echo __('Re-assign task to', 'processmaker')."&nbsp;";
 echo "<input type='hidden' name='action' value='reassign_reminder'>";
 echo "<input type='hidden' name='comment' id='comment$rand' value=''>";
 echo $commoninputs;
+
+echo '<table class="tab_cadre_fixe">';
+echo '<tr>';
+echo '<td class="tab_bg_1" nowrap>';
+echo "<b>" . __('Re-assign task to', 'processmaker') . "</b>";
+echo '</td>';
 
 $can_unclaim = false; // by default
 $grp = false;
@@ -76,20 +81,53 @@ if ($PM_DB->numrows($res) > 0 && $row = $PM_DB->fetchAssoc($res)) {
       $grp = $PM_SOAP->getGLPIGroupIdForSelfServiceTask($_REQUEST['caseGuid'], $_REQUEST['taskGuid']);
    }
 }
+$task_table = getTableForItemType($_REQUEST['tasktype']);
 
 $res = $DB->request([
             'SELECT'    => [
             'pm.is_reassignreason_mandatory AS pm_is_reassignreason_mandatory',
-            'gppp.is_reassignreason_mandatory AS gppp_is_reassignreason_mandatory'
+            'gppp.is_reassignreason_mandatory AS gppp_is_reassignreason_mandatory',
+            'pm.before_time AS pm_before_time',
+            'pm.after_time AS pm_after_time',
+            'pm.users_id AS pm_users_id',
+            'gpptr.before_time AS tr_before_time',
+            'gpptr.after_time AS tr_after_time',
+            'gpptr.users_id AS tr_users_id',
+            'gpptr.id AS plugin_processmaker_taskrecalls_id',
+            'gtt.begin AS task_begin',
+            'gtt.end AS task_end',
+            'gpptr.when AS tr_when',
+            'gppt.id AS pm_tasks_id'
             ],
             'FROM'      => 'glpi_plugin_processmaker_taskcategories AS pm',
             'LEFT JOIN' => [
-            'glpi_plugin_processmaker_processes AS gppp' => [
-                'FKEY' => [
-                    'gppp' => 'id',
-                    'pm'   => 'plugin_processmaker_processes_id'
+                'glpi_plugin_processmaker_processes AS gppp' => [
+                    'ON' => [
+                        'gppp' => 'id',
+                        'pm'   => 'plugin_processmaker_processes_id'
+                    ]
+                ],
+                'glpi_plugin_processmaker_tasks as gppt' => [
+                    'ON' => [
+                        'pm' => 'id',
+                        'gppt' => 'plugin_processmaker_taskcategories_id',
+                        ['AND' => ['gppt.items_id' => $_REQUEST['tasks_id'],
+                                   'gppt.itemtype'=> $_REQUEST['tasktype']]
+                        ]
+                    ]
+                ],
+                'glpi_plugin_processmaker_taskrecalls as gpptr' => [
+                    'ON' => [
+                        'gpptr' => 'plugin_processmaker_tasks_id',
+                        'gppt' => 'id'
+                    ]
+                ],
+                $task_table . ' as gtt' => [
+                    'ON' => [
+                        'gtt' => 'id',
+                        'gppt' => 'items_id'
+                    ]
                 ]
-            ]
             ],
             'WHERE'     => [
             'pm.pm_task_guid' => $_REQUEST['taskGuid']
@@ -100,9 +138,10 @@ $res = $DB->request([
 $taskCat = $res->current();
 $ask_for_reason = PluginProcessmakerTaskCategory::inheritedReAssignReason($taskCat['pm_is_reassignreason_mandatory'], $taskCat['gppp_is_reassignreason_mandatory']);
 
+echo '<td class="tab_bg_1" colspan=2 nowrap>';
 PluginProcessmakerUser::dropdown( ['name'   => 'users_id_recipient',
                                    'value'  => $_REQUEST['users_id'],
-                                   //'used' => $_REQUEST['used'], // not set to be able to alert when trying to re-assigned to the same user
+                                   'used' => $_REQUEST['used'] ?? [],
                                    'entity' => 0, //$item->fields["entities_id"], // not used, as any user can be assigned to any tasks
                                    'entity_sons' => false, // not used, as any user can be assigned to any tasks
                                    'right'  => 'all',
@@ -111,8 +150,9 @@ PluginProcessmakerUser::dropdown( ['name'   => 'users_id_recipient',
                                    'width' => '',
                                    'specific_tags' => ['taskGuid' => $_REQUEST['taskGuid'], 'grpGuid' => ($grp !== false ? $grp['uid'] : 0)]
                                   ]);
+echo '</td>';
+echo '<td class="tab_bg_1" nowrap>';
 
-echo "&nbsp;&nbsp;";
 echo "<input type='submit' name='reassign$rand' value='".__('Re-assign', 'processmaker')."' class='submit'>";
 echo "<input type='submit' name='reassign' id='reassign$rand' value='".__('Re-assign', 'processmaker')."' class='submit' style='display:none'>";
 
@@ -205,10 +245,217 @@ echo HTML::scriptBlock("
       })
    ");
 
+echo '</td>';
 
-if (Session::getLoginUserID() != $_REQUEST['users_id']) {
-   echo "&nbsp;&nbsp;";
-   echo "<input type='submit' name='reminder' value='".__('Send reminder', 'processmaker')."' class='submit'>";
+echo '<td class="tab_bg_1" colspan="2">';
+echo '</td>';
+
+
+echo '<td class="tab_bg_1" colspan=2>';
+if (!isset($PM_SOAP->config)) {
+    $PM_SOAP->config = Config::getConfigurationValues('plugin:processmaker');
 }
+if (Session::getLoginUserID() != $_REQUEST['users_id']
+    && $PM_SOAP->config['users_id'] != $_REQUEST['users_id']) {
+   echo "<input type='submit' name='reminder' value='".__('Send immediate reminder', 'processmaker')."' class='submit'>";
+}
+echo '</td>';
+
+// check rights
+$caneditreminders = Session::getCurrentInterface() == 'central' && $PM_SOAP->config['users_id'] != $_REQUEST['users_id'];
+
+if ($caneditreminders) {
+    echo '<td class="tab_bg_1" colspan=2>';
+    echo '<div class="pointer" onclick="showHideReminderSettings();">Automatic reminder settings&nbsp;<i id="reminder_arrow" class="fas fa-caret-down pointer" style="font-size: larger;" title="Show/Hide"></i></div>';
+    echo Html::scriptBlock("
+        function showHideReminderSettings() {
+            if ($('.reminder_settings').css('display') == 'none') {
+                $('.reminder_settings').css('display', '');
+            } else {
+                $('.reminder_settings').css('display', 'none');
+            }
+            $('#reminder_arrow').toggleClass('fa-caret-up fa-caret-down');
+        }
+    ");
+    echo '</td>';
+}
+
+echo '</tr>';
+echo '</table>';
+
+
+if ($caneditreminders) {
+    // add info on reminder
+    // show before time
+    // show after time
+    // show next date
+    // show user
+    // add submit button
+    echo Html::scriptBlock("
+        function formatedTimestamp (d, hm_only) {
+            const date = d.toISOString().split('T')[0];
+            const time = d.toTimeString().split(' ')[0];
+            if (typeof hm_only === 'undefined' && hm_only === true) {
+                return date + ' ' + time;
+            }
+            const hm = time.split(':')
+            return date + ' ' + hm[0] + ':' + hm[1];
+        }
+
+        function computeNextDate (elt_name, new_date_name, ref_name, ope) {
+            var delta = $('[name=' + elt_name + ']').val() * 1000; // in milliseconds
+            var ref = $('[name=' + ref_name + ']').val(); // date_begin or date_end
+            var new_date = __('None', 'processmaker'); // by default
+            if (delta >= 0) {
+                if (ope === 'sub') {
+                    delta = -delta;
+                }
+                new_date = formatedTimestamp(new Date(Date.parse(ref) + delta));
+                var current_date = formatedTimestamp(new Date());
+                if (new_date < current_date) {
+                    new_date = formatedTimestamp(new Date(Date.parse(current_date) + delta));
+                }
+            }
+            $('[name=' + new_date_name + ']').val(new_date);
+            $('#' + new_date_name).text(new_date);
+        }
+
+        function selectUser (userid, username) {
+            // Set the actual_users_id value, creating a new option if necessary
+            if ($('[name=actual_users_id]').find('option[value=' + userid + ']').length) {
+                $('[name=actual_users_id]').val(userid).trigger('change');
+            } else { 
+                // Create a DOM Option and pre-select by default
+                var newOption = new Option(decodeURIComponent(username.replace(/\+/g, ' ')), userid, true, true);
+                // Append it to the select
+                $('[name=actual_users_id]').append(newOption).trigger('change');
+            }
+        }
+
+        function reset2Defaults () {
+            if ($('[name=actual_before_time]').val() != " . PluginProcessmakerTaskCategory::REMINDER_STOP . "
+                && $('[name=task_begin]').val() > '" . $_SESSION["glpi_currenttime"] . "') {
+                $('[name=actual_before_time]').val($('[name=default_before_time]').val()).trigger('change');
+            }
+
+            $('[name=actual_after_time]').val($('[name=default_after_time]').val()).trigger('change');
+
+            // Set the actual_users_id value, creating a new option if necessary
+            selectUser($('[name=default_users_id]').val(), $('[name=default_user_name]').val());
+        }
+    ");
+    echo "<input type='hidden' name='plugin_processmaker_taskrecalls_id' value='".$taskCat['plugin_processmaker_taskrecalls_id']."'>";
+    echo "<input type='hidden' name='task_begin' value='".$taskCat['task_begin']."'>";
+    echo "<input type='hidden' name='task_end' value='".$taskCat['task_end']."'>";
+    echo "<input type='hidden' name='plugin_processmaker_tasks_id' value='".$taskCat['pm_tasks_id']."'>";
+
+    echo '<hr class="reminder_settings" style="display:none">';
+    echo '<table class="tab_cadre_fixe reminder_settings" style="display:none">';
+
+    echo "<input type='hidden' name='default_before_time' value='{$taskCat['pm_before_time']}'>";
+    echo "<input type='hidden' name='default_after_time' value='{$taskCat['pm_after_time']}'>";
+
+    $taskCat['pm_users_id'] = $taskCat['pm_users_id'] ?? 0;
+    echo "<input type='hidden' name='default_users_id' value='{$taskCat['pm_users_id']}'>";
+
+    $user_info = urlencode($taskCat['pm_users_id'] > 0 ? getUserName($taskCat['pm_users_id']) : Dropdown::EMPTY_VALUE);
+    echo "<input type='hidden' name='default_user_name' value='{$user_info}'>";
+
+    echo '<tr>';
+
+    echo '<td class="tab_bg_1 pm_reminder" nowrap>';
+    echo "<i>" . __('Before start (once)', 'processmaker') . "</i>&nbsp;";
+    echo '</td>';
+    echo '<td class="tab_bg_1" nowrap>';
+    if ($taskCat['tr_before_time'] === null) {
+        $taskCat['tr_before_time'] = PluginProcessmakerTaskCategory::REMINDER_NONE;
+    }
+    if ($taskCat['tr_before_time'] == PluginProcessmakerTaskCategory::REMINDER_STOP) {
+        echo __('Done', 'processmaker');
+        echo "<input type='hidden' name='actual_before_time' value='". PluginProcessmakerTaskCategory::REMINDER_STOP ."'>";
+    } else if ($_SESSION["glpi_currenttime"] > $taskCat['task_begin']) {
+        echo __('None');
+        echo "<input type='hidden' name='actual_before_time' value='". PluginProcessmakerTaskCategory::REMINDER_NONE ."'>";
+    } else {
+        Dropdown::showFromArray('actual_before_time', PluginProcessmakerTaskCategory::getAllBeforeReminders(), [
+            'value'     => $taskCat['tr_before_time'],
+            'on_change' => 'computeNextDate("actual_before_time", "next_reminder_before", "task_begin", "sub");'
+        ]);
+    }
+    echo '</td>';
+
+    echo '<td class="tab_bg_1 pm_reminder" nowrap>';
+    echo "<i>" . __('After end (every)', 'processmaker') . "</i>";
+    echo '</td>';
+    echo '<td class="tab_bg_1" nowrap>';
+    if ($taskCat['tr_after_time'] === null) {
+        $taskCat['tr_after_time'] = PluginProcessmakerTaskCategory::REMINDER_NONE;
+    }
+    Dropdown::showFromArray('actual_after_time', PluginProcessmakerTaskCategory::getAllAfterReminders(), [
+        'value' => $taskCat['tr_after_time'],
+        'on_change' => 'computeNextDate("actual_after_time", "next_reminder_after", "task_end", "add");'
+    ]);
+    echo '</td>';
+
+    echo '<td class="tab_bg_1" nowrap>';
+    echo "<i>" . __('Sender', 'processmaker') . "</i>";
+    echo "&nbsp;&nbsp;&nbsp;";
+    $user_info = urlencode(getUserName(Session::getLoginUserID()));
+    echo "<i class='fas fa-male pointer' title='" . __('Set me as sender', 'processmaker') . "' onclick=\"selectUser(" . Session::getLoginUserID() . ", '{$user_info}');\"></i>";
+    echo '</td>';
+    echo '<td class="tab_bg_1" nowrap>';
+    User::dropdown(['name'                 => 'actual_users_id',
+                    'display_emptychoice'  => true,
+                    'right'                => 'all',
+                    'width'                => '',
+                    'value'                => $taskCat['tr_users_id']]);
+
+    echo '</td>';
+    echo '</tr>';
+
+    echo '<tr>';
+
+    echo '<td class="tab_bg_1 pm_reminder" nowrap>';
+    echo "<i>" . __('When', 'processmaker') . "</i>&nbsp;";
+    echo '</td>';
+    echo '<td id="next_reminder_before" class="tab_bg_1" nowrap>';
+    if ($taskCat['tr_before_time'] == PluginProcessmakerTaskCategory::REMINDER_NONE) {
+        $next_reminder_before = __('None', 'processmaker');
+    } elseif ($taskCat['tr_before_time'] == PluginProcessmakerTaskCategory::REMINDER_STOP) {
+        $next_reminder_before = __('Done', 'processmaker');
+    } else {
+        $next_reminder_before = $taskCat['tr_when'];
+    }
+    echo strtotime($next_reminder_before) ? date("Y-m-d H:i", strtotime($next_reminder_before)) : $next_reminder_before;
+    echo '</td>';
+    echo "<input type='hidden' name='next_reminder_before' value='$next_reminder_before' readonly>";
+
+    echo '<td class="tab_bg_1 pm_reminder" nowrap>';
+    echo "<i>" . __('Next occurrence', 'processmaker') . "</i>&nbsp;";
+    echo '</td>';
+    echo '<td id="next_reminder_after" class="tab_bg_1" nowrap>';
+    if ($taskCat['tr_after_time'] == PluginProcessmakerTaskCategory::REMINDER_NONE) {
+        $next_reminder_after = __('None', 'processmaker');
+    } else {
+        $next_reminder_after = ($taskCat['tr_before_time'] >= 0 ? date("Y-m-d H:i:s", strtotime($taskCat['task_end']) + $taskCat['tr_after_time']) : $taskCat['tr_when']);
+    }
+    echo strtotime($next_reminder_after) ? date("Y-m-d H:i", strtotime($next_reminder_after)) : $next_reminder_after;
+    echo '</td>';
+    echo "<input type='hidden' name='next_reminder_after' value='$next_reminder_after' readonly>";
+
+    echo '<td>';
+    echo "<i class='fas fa-sync pointer' style='font-size: larger;' title='" . __('Reset to defaults', 'processmaker') . "' onclick='reset2Defaults();'></i>";
+    echo '</td>';
+
+    echo '<td class="tab_bg_1">';
+    echo "<input type='submit' name='reminder_settings' value='".__('Save', 'processmaker')."' class='submit'>";
+    echo '</td>';
+
+    echo '</tr>';
+
+    echo '</table>';
+}
+
+echo '<hr style="border: 1px solid lightgrey;">';
 
 Html::closeForm(true);

--- a/css/task.css
+++ b/css/task.css
@@ -1,7 +1,7 @@
 ﻿/*
  -------------------------------------------------------------------------
 ProcessMaker plugin for GLPI
-Copyright (C) 2014-2023 by Raynet SAS a company of A.Raymond Network.
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
 
 https://www.araymond.com/
 -------------------------------------------------------------------------
@@ -27,7 +27,7 @@ along with this plugin. If not, see <http://www.gnu.org/licenses/>.
 span.pm_task, a.pm_task {
    float: right;
    color: #fff !important;
-   border-radius: 8px;
+   border-radius: 4px;
    padding-left: 8px;
    line-height: 1.5;
 }
@@ -43,4 +43,10 @@ span.pm_task_case {
    margin-left: 8px;
    flex: none;
    align-self: flex-start;
+}
+
+td.pm_reminder {
+   border-left-color: lightgrey;
+   border-left-width: 1px;
+   border-left-style: solid;
 }

--- a/front/case.form.php
+++ b/front/case.form.php
@@ -2,7 +2,7 @@
 /*
 -------------------------------------------------------------------------
 ProcessMaker plugin for GLPI
-Copyright (C) 2014-2023 by Raynet SAS a company of A.Raymond Network.
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
 
 https://www.araymond.com/
 -------------------------------------------------------------------------

--- a/front/case.php
+++ b/front/case.php
@@ -2,7 +2,7 @@
 /*
 -------------------------------------------------------------------------
 ProcessMaker plugin for GLPI
-Copyright (C) 2014-2023 by Raynet SAS a company of A.Raymond Network.
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
 
 https://www.araymond.com/
 -------------------------------------------------------------------------

--- a/front/caselink.form.php
+++ b/front/caselink.form.php
@@ -2,7 +2,7 @@
 /*
 -------------------------------------------------------------------------
 ProcessMaker plugin for GLPI
-Copyright (C) 2014-2023 by Raynet SAS a company of A.Raymond Network.
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
 
 https://www.araymond.com/
 -------------------------------------------------------------------------

--- a/front/caselink.php
+++ b/front/caselink.php
@@ -2,7 +2,7 @@
 /*
 -------------------------------------------------------------------------
 ProcessMaker plugin for GLPI
-Copyright (C) 2014-2023 by Raynet SAS a company of A.Raymond Network.
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
 
 https://www.araymond.com/
 -------------------------------------------------------------------------

--- a/front/config.form.php
+++ b/front/config.form.php
@@ -1,5 +1,29 @@
 <?php
-/**
+/*
+-------------------------------------------------------------------------
+ProcessMaker plugin for GLPI
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
+
+https://www.araymond.com/
+-------------------------------------------------------------------------
+
+LICENSE
+
+This file is part of ProcessMaker plugin for GLPI.
+
+This file is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This plugin is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this plugin. If not, see <http://www.gnu.org/licenses/>.
+--------------------------------------------------------------------------
  */
 
 include ( "../../../inc/includes.php");

--- a/front/crontaskaction.form.php
+++ b/front/crontaskaction.form.php
@@ -2,7 +2,7 @@
 /*
 -------------------------------------------------------------------------
 ProcessMaker plugin for GLPI
-Copyright (C) 2014-2023 by Raynet SAS a company of A.Raymond Network.
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
 
 https://www.araymond.com/
 -------------------------------------------------------------------------

--- a/front/crontaskaction.php
+++ b/front/crontaskaction.php
@@ -2,7 +2,7 @@
 /*
 -------------------------------------------------------------------------
 ProcessMaker plugin for GLPI
-Copyright (C) 2014-2023 by Raynet SAS a company of A.Raymond Network.
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
 
 https://www.araymond.com/
 -------------------------------------------------------------------------

--- a/front/document.send.php
+++ b/front/document.send.php
@@ -2,7 +2,7 @@
 /*
 -------------------------------------------------------------------------
 ProcessMaker plugin for GLPI
-Copyright (C) 2014-2023 by Raynet SAS a company of A.Raymond Network.
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
 
 https://www.araymond.com/
 -------------------------------------------------------------------------

--- a/front/index.php
+++ b/front/index.php
@@ -2,7 +2,7 @@
 /*
 -------------------------------------------------------------------------
 ProcessMaker plugin for GLPI
-Copyright (C) 2014-2023 by Raynet SAS a company of A.Raymond Network.
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
 
 https://www.araymond.com/
 -------------------------------------------------------------------------

--- a/front/process.form.php
+++ b/front/process.form.php
@@ -2,7 +2,7 @@
 /*
 -------------------------------------------------------------------------
 ProcessMaker plugin for GLPI
-Copyright (C) 2014-2023 by Raynet SAS a company of A.Raymond Network.
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
 
 https://www.araymond.com/
 -------------------------------------------------------------------------

--- a/front/process.php
+++ b/front/process.php
@@ -2,7 +2,7 @@
 /*
 -------------------------------------------------------------------------
 ProcessMaker plugin for GLPI
-Copyright (C) 2014-2023 by Raynet SAS a company of A.Raymond Network.
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
 
 https://www.araymond.com/
 -------------------------------------------------------------------------

--- a/front/process_profile.form.php
+++ b/front/process_profile.form.php
@@ -2,7 +2,7 @@
 /*
 -------------------------------------------------------------------------
 ProcessMaker plugin for GLPI
-Copyright (C) 2014-2023 by Raynet SAS a company of A.Raymond Network.
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
 
 https://www.araymond.com/
 -------------------------------------------------------------------------

--- a/front/processmaker.form.php
+++ b/front/processmaker.form.php
@@ -2,7 +2,7 @@
 /*
 -------------------------------------------------------------------------
 ProcessMaker plugin for GLPI
-Copyright (C) 2014-2023 by Raynet SAS a company of A.Raymond Network.
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
 
 https://www.araymond.com/
 -------------------------------------------------------------------------
@@ -51,17 +51,20 @@ switch ($_REQUEST["action"]) {
 
                   //$task->getFromDBByQuery(" WHERE `plugin_processmaker_cases_id`=".$case->getID()); // normally there is only one and only one first task
                   //$link .= '&forcetab=PluginProcessmakerTask$'.$task->getID();
-
-                  Session::setActiveTab('PluginProcessmakerCase', 'PluginProcessmakerTask$'.$task->fields['id']);
-                  $item = new $_REQUEST['itemtype'];
-                  $item->getFromDB($_REQUEST['items_id']);
-                  unset($_SERVER['REQUEST_URI']); // to prevent use of processmaker.form.php in NavigateList
-                  Session::initNavigateListItems('PluginProcessmakerCase',
-                        //TRANS : %1$s is the itemtype name,
+                  if (!isset($_REQUEST['timeline'])) {
+                       Session::setActiveTab('PluginProcessmakerCase', 'PluginProcessmakerTask$'.$task->fields['id']);
+                       $item = new $_REQUEST['itemtype'];
+                       $item->getFromDB($_REQUEST['items_id']);
+                       unset($_SERVER['REQUEST_URI']); // to prevent use of processmaker.form.php in NavigateList
+                       Session::initNavigateListItems('PluginProcessmakerCase',
+                             //TRANS : %1$s is the itemtype name,
                         //        %2$s is the name of the item (used for headings of a list)
-                                  sprintf('%1$s = %2$s',
-                                          $_REQUEST['itemtype']::getTypeName(1), $item->fields["name"]));
-                  Html::redirect($link);
+                                       sprintf('%1$s = %2$s',
+                                               $_REQUEST['itemtype']::getTypeName(1), $item->fields["name"]));
+                       Html::redirect($link);
+                  } else if ($_REQUEST['timeline']) {
+                      Html::back();
+                  }
                }
                Html::back();
             } else {
@@ -138,7 +141,7 @@ switch ($_REQUEST["action"]) {
             }
          }
       } elseif (isset($_REQUEST['reminder'])) {
-         // send notification remider as requested for this task
+         // send notification reminder as requested for this task
 
          $locCase = new PluginProcessmakerCase;
          $locCase->getFromDB($_REQUEST['cases_id']);
@@ -151,6 +154,71 @@ switch ($_REQUEST["action"]) {
 
          // send notification now!
          $pm_task->sendNotification('task_reminder', $glpi_task, $glpi_item, $locCase);
+
+         // Add a follow-up in the hosting item to indicate the sending of the reminder
+         $fu = new ITILFollowup();
+         $input = $fu->fields;
+
+         $fucontent = sprintf(
+             __("Case: '%s',<br>Task: '%s',<br>A reminder has been sent to:<br>", 'processmaker'),
+             $locCase->fields['name'],
+             Dropdown::getDropdownName("glpi_taskcategories", $glpi_task->fields["taskcategories_id"])
+             );
+
+         if (isset($glpi_task->fields['users_id_tech']) && $glpi_task->fields['users_id_tech'] > 0) {
+             // get infos for user
+             $dbu = new DbUtils;
+             $userinfos = $dbu->getUserName($glpi_task->fields['users_id_tech'], 2);
+             $fucontent .= "-> " . $userinfos['name'] . "<br>";
+         }
+
+         if (isset($glpi_task->fields['groups_id_tech']) && $glpi_task->fields['groups_id_tech'] > 0) {
+             // get infos for group
+             $grp = new Group();
+             $grp->getFromDB($glpi_task->fields['groups_id_tech']);
+             $fucontent .= "-> " . $grp->fields['name'] . "<br>";
+         }
+
+         $input['content'] = $DB->escape($fucontent);
+         $input['is_private'] = 0;
+         //$input['requesttypes_id'] = ;
+         $input['items_id'] = $_REQUEST['items_id'];
+         $input['users_id'] = Session::getLoginUserID(true);
+         $input['itemtype'] = $_REQUEST['itemtype'];
+
+         $fu->add($input);
+
+      } elseif (isset($_REQUEST['reminder_settings'])) {
+          // here we must add/update the taskrecalls
+          $recall = new PluginProcessmakerTaskrecall();
+          // if the new_when is less than glpi_currenttime, then set it to glpi_currenttime 
+          // to prevent send of many "after reminders" in case of late cron that missed several "after reminders"
+          // if the new_when is less than glpi_currenttime, then set it to glpi_currenttime
+          $new_when = -1; // by default will delete any records
+          if (isset($_REQUEST['actual_before_time']) && $_REQUEST['actual_before_time'] >= 0) {
+              $new_when = $_REQUEST['next_reminder_before'];
+          } elseif ($_REQUEST['actual_after_time'] >= 0) {
+              $new_when = $_REQUEST['next_reminder_after'];
+          }
+          if ($new_when !== -1 && $_REQUEST['plugin_processmaker_taskrecalls_id'] > 0) {
+              $recall->update([
+                  'id'          => $_REQUEST['plugin_processmaker_taskrecalls_id'],
+                  'before_time' => $_REQUEST['actual_before_time'],
+                  'after_time'  => $_REQUEST['actual_after_time'],
+                  'when'        => $new_when,
+                  'users_id'    => $_REQUEST['actual_users_id']
+                  ]);
+          } elseif ($new_when !== -1) {
+              $recall->add([
+                  'plugin_processmaker_tasks_id' => $_REQUEST['plugin_processmaker_tasks_id'],
+                  'before_time'                  => $_REQUEST['actual_before_time'],
+                  'after_time'                   => $_REQUEST['actual_after_time'],
+                  'when'                         => $new_when,
+                  'users_id'                     => $_REQUEST['actual_users_id']
+                  ]);
+          } elseif ($_REQUEST['plugin_processmaker_taskrecalls_id'] > 0) {
+              $recall->delete(['id' => $_REQUEST['plugin_processmaker_taskrecalls_id']]);
+          }
       }
 }
 

--- a/front/processmaker.helpdesk.form.php
+++ b/front/processmaker.helpdesk.form.php
@@ -3,7 +3,7 @@ use Symfony\Component\DomCrawler\Crawler;
 /*
 -------------------------------------------------------------------------
 ProcessMaker plugin for GLPI
-Copyright (C) 2014-2023 by Raynet SAS a company of A.Raymond Network.
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
 
 https://www.araymond.com/
 -------------------------------------------------------------------------
@@ -108,8 +108,15 @@ function processMakerShowCase($users_id, $from_helpdesk) {
       $tkt->showFormHelpdesk($users_id);
 
       $buffer = ob_get_clean();
+      //if (ob_get_level() > 1) {
+      //    echo $buffer;
+      //    $buffer = ob_get_clean();
+      //}
+      
+      //to change this HTML code
+      $rand = rand();
+      $buffer = preg_replace(['@</i>\s+</span>`@',"@'</span>',@", "@&nbsp;@", "@</i>\s+</button>`;@", "@</span>`@", "@</i>`@"], ["icon_span_$rand`","'post_span_$rand',", "nbsp_$rand", "icon_button_$rand`;", "span_$rand`", "icon_$rand`"], $buffer);
 
-      // to change this HTML code
       $crawler = new Crawler();
       $crawler->addHtmlContent($buffer);
 
@@ -122,7 +129,7 @@ function processMakerShowCase($users_id, $from_helpdesk) {
       $crawler->filter('[name=add]')->getNode(0)->setAttribute('style', 'display:none;');
 
       // add an input for processguid in the form
-      $formNode = $crawler->filter('#itil-form');
+      $formNode = $crawler->filter('div.card');
       $input = $formNode->getNode(0)->appendChild(new DOMElement('input'));
       $input->setAttribute('name', 'processmaker_process_guid');
       $input->setAttribute('type', 'hidden');
@@ -191,10 +198,13 @@ function processMakerShowCase($users_id, $from_helpdesk) {
          ]));
       $iframe->setAttribute(
           'src',
-"{$PM_SOAP->serverURL}/cases/cases_Open?sid={$PM_SOAP->getPMSessionID()}&APP_UID={$caseInfo->caseId}&{$paramsURL}&glpi_data={$glpi_data}"
-          );
+          "{$PM_SOAP->serverURL}/cases/cases_Open?sid={$PM_SOAP->getPMSessionID()}&APP_UID={$caseInfo->caseId}&{$paramsURL}&glpi_data={$glpi_data}"
+      );
 
-      echo $crawler->html();
+      $buffer = $crawler->html();
+      $buffer = str_replace(["icon_span_$rand`", "'post_span_$rand',", "nbsp_$rand", "icon_button_$rand`;", "span_$rand`", "icon_$rand`"], ['</i> </span>`', "'</span>',", "&nbsp;", "</i> </button>`;", "</span>`", "</i>`"], $buffer);
+
+      echo $buffer;
    }
 
 }

--- a/front/taskcategory.form.php
+++ b/front/taskcategory.form.php
@@ -2,7 +2,7 @@
 /*
 -------------------------------------------------------------------------
 ProcessMaker plugin for GLPI
-Copyright (C) 2014-2023 by Raynet SAS a company of A.Raymond Network.
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
 
 https://www.araymond.com/
 -------------------------------------------------------------------------

--- a/front/tracking.injector.php
+++ b/front/tracking.injector.php
@@ -2,7 +2,7 @@
 /*
 -------------------------------------------------------------------------
 ProcessMaker plugin for GLPI
-Copyright (C) 2014-2023 by Raynet SAS a company of A.Raymond Network.
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
 
 https://www.araymond.com/
 -------------------------------------------------------------------------

--- a/inc/casechangelog.class.php
+++ b/inc/casechangelog.class.php
@@ -2,7 +2,7 @@
 /*
 -------------------------------------------------------------------------
 ProcessMaker plugin for GLPI
-Copyright (C) 2014-2023 by Raynet SAS a company of A.Raymond Network.
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
 
 https://www.araymond.com/
 -------------------------------------------------------------------------

--- a/inc/casehistory.class.php
+++ b/inc/casehistory.class.php
@@ -2,7 +2,7 @@
 /*
 -------------------------------------------------------------------------
 ProcessMaker plugin for GLPI
-Copyright (C) 2014-2023 by Raynet SAS a company of A.Raymond Network.
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
 
 https://www.araymond.com/
 -------------------------------------------------------------------------

--- a/inc/casehistorydynaformpage.class.php
+++ b/inc/casehistorydynaformpage.class.php
@@ -2,7 +2,7 @@
 /*
 -------------------------------------------------------------------------
 ProcessMaker plugin for GLPI
-Copyright (C) 2014-2023 by Raynet SAS a company of A.Raymond Network.
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
 
 https://www.araymond.com/
 -------------------------------------------------------------------------

--- a/inc/caselink.class.php
+++ b/inc/caselink.class.php
@@ -2,7 +2,7 @@
 /*
 -------------------------------------------------------------------------
 ProcessMaker plugin for GLPI
-Copyright (C) 2014-2023 by Raynet SAS a company of A.Raymond Network.
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
 
 https://www.araymond.com/
 -------------------------------------------------------------------------

--- a/inc/caselinkaction.class.php
+++ b/inc/caselinkaction.class.php
@@ -2,7 +2,7 @@
 /*
 -------------------------------------------------------------------------
 ProcessMaker plugin for GLPI
-Copyright (C) 2014-2023 by Raynet SAS a company of A.Raymond Network.
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
 
 https://www.araymond.com/
 -------------------------------------------------------------------------

--- a/inc/casemap.class.php
+++ b/inc/casemap.class.php
@@ -2,7 +2,7 @@
 /*
 -------------------------------------------------------------------------
 ProcessMaker plugin for GLPI
-Copyright (C) 2014-2023 by Raynet SAS a company of A.Raymond Network.
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
 
 https://www.araymond.com/
 -------------------------------------------------------------------------

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -2,7 +2,7 @@
 /*
 -------------------------------------------------------------------------
 ProcessMaker plugin for GLPI
-Copyright (C) 2014-2023 by Raynet SAS a company of A.Raymond Network.
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
 
 https://www.araymond.com/
 -------------------------------------------------------------------------

--- a/inc/crontaskaction.class.php
+++ b/inc/crontaskaction.class.php
@@ -2,7 +2,7 @@
 /*
 -------------------------------------------------------------------------
 ProcessMaker plugin for GLPI
-Copyright (C) 2014-2023 by Raynet SAS a company of A.Raymond Network.
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
 
 https://www.araymond.com/
 -------------------------------------------------------------------------

--- a/inc/db.class.php
+++ b/inc/db.class.php
@@ -2,7 +2,7 @@
 /*
 -------------------------------------------------------------------------
 ProcessMaker plugin for GLPI
-Copyright (C) 2014-2023 by Raynet SAS a company of A.Raymond Network.
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
 
 https://www.araymond.com/
 -------------------------------------------------------------------------

--- a/inc/document.class.php
+++ b/inc/document.class.php
@@ -2,7 +2,7 @@
 /*
 -------------------------------------------------------------------------
 ProcessMaker plugin for GLPI
-Copyright (C) 2014-2023 by Raynet SAS a company of A.Raymond Network.
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
 
 https://www.araymond.com/
 -------------------------------------------------------------------------

--- a/inc/menu.class.php
+++ b/inc/menu.class.php
@@ -2,7 +2,7 @@
 /*
 -------------------------------------------------------------------------
 ProcessMaker plugin for GLPI
-Copyright (C) 2014-2023 by Raynet SAS a company of A.Raymond Network.
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
 
 https://www.araymond.com/
 -------------------------------------------------------------------------

--- a/inc/notificationtargetcase.class.php
+++ b/inc/notificationtargetcase.class.php
@@ -2,7 +2,7 @@
 /*
 -------------------------------------------------------------------------
 ProcessMaker plugin for GLPI
-Copyright (C) 2014-2023 by Raynet SAS a company of A.Raymond Network.
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
 
 https://www.araymond.com/
 -------------------------------------------------------------------------

--- a/inc/notificationtargetprocessmaker.class.php
+++ b/inc/notificationtargetprocessmaker.class.php
@@ -2,7 +2,7 @@
 /*
 -------------------------------------------------------------------------
 ProcessMaker plugin for GLPI
-Copyright (C) 2014-2023 by Raynet SAS a company of A.Raymond Network.
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
 
 https://www.araymond.com/
 -------------------------------------------------------------------------

--- a/inc/notificationtargettask.class.php
+++ b/inc/notificationtargettask.class.php
@@ -3,7 +3,7 @@ use Glpi\Toolbox\Sanitizer;
 /*
 -------------------------------------------------------------------------
 ProcessMaker plugin for GLPI
-Copyright (C) 2014-2023 by Raynet SAS a company of A.Raymond Network.
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
 
 https://www.araymond.com/
 -------------------------------------------------------------------------
@@ -44,10 +44,23 @@ class PluginProcessmakerNotificationTargetTask extends PluginProcessmakerNotific
               'task_reassign' => ['event' => 'task_reassign_', 'label' => __('Task re-assign'), 'glpi' => 'update_task'],
               'task_unclaim'  => ['event' => 'task_unclaim_',  'label' => __('Task un-claim'),  'glpi' => 'update_task'],
               'task_done'     => ['event' => 'task_done_',     'label' => __('Task done'),      'glpi' => 'update_task'],
-              'task_reminder' => ['event' => 'task_reminder_', 'label' => __('Task reminder'),  'glpi' => 'update_task']
+              'task_reminder' => ['event' => 'task_reminder_', 'label' => __('Task reminder'),  'glpi' => 'update_task'],
+              'task_overdue'  => ['event' => 'task_overdue_',  'label' => __('Task overdue'),   'glpi' => 'update_task']
              ];
    }
 
+
+   public function getSender(): array {
+       $sender = parent::getSender();
+       $users_id = $this->obj->getSender();
+       if ($users_id > 0) {
+            $usr = new User();
+            $usr->getFromDB($users_id);
+            $sender['name']  = $usr->getFriendlyName();
+            $sender['email'] = $usr->getDefaultEmail();
+       }
+       return $sender;
+   }
 
    /**
     * Summary of getDefaultGLPIEvents

--- a/inc/processCategory.class.php
+++ b/inc/processCategory.class.php
@@ -26,13 +26,33 @@ along with this plugin. If not, see <http://www.gnu.org/licenses/>.
 --------------------------------------------------------------------------
  */
 /**
- * selfservicedraft short summary.
+ * PluginProcessmakerTaskCategory short summary.
  *
- * selfservicedraft description.
+ * PluginProcessmakerTaskCategory description.
  *
  * @version 1.0
- * @author morono
+ * @author MoronO
  */
-class PluginProcessmakerSelfservicedraft extends CommonDBTM {
+
+if (!defined('GLPI_ROOT')) {
+   die("Sorry. You can't access directly to this file");
+}
+
+
+class PluginProcessmakerProcessCategory extends CommonDBTM
+{
+   static function refreshCategories() {
+       global $PM_DB;
+
+       $processCategories = new self;
+       foreach($PM_DB->request('PROCESS_CATEGORY') as $data) {
+           if (!$processCategories->getFromDBByCrit(["category_guid" => $data['CATEGORY_UID']])) {
+               $processCategories->add([
+                    'name' => $data['CATEGORY_NAME'],
+                    'category_guid' => $data['CATEGORY_UID']
+               ]);
+           }
+       }
+   }
 
 }

--- a/inc/process_profile.class.php
+++ b/inc/process_profile.class.php
@@ -2,7 +2,7 @@
 /*
 -------------------------------------------------------------------------
 ProcessMaker plugin for GLPI
-Copyright (C) 2014-2023 by Raynet SAS a company of A.Raymond Network.
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
 
 https://www.araymond.com/
 -------------------------------------------------------------------------

--- a/inc/profile.class.php
+++ b/inc/profile.class.php
@@ -2,7 +2,7 @@
 /*
 -------------------------------------------------------------------------
 ProcessMaker plugin for GLPI
-Copyright (C) 2014-2023 by Raynet SAS a company of A.Raymond Network.
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
 
 https://www.araymond.com/
 -------------------------------------------------------------------------

--- a/inc/taskalert.class.php
+++ b/inc/taskalert.class.php
@@ -25,14 +25,6 @@ You should have received a copy of the GNU General Public License
 along with this plugin. If not, see <http://www.gnu.org/licenses/>.
 --------------------------------------------------------------------------
  */
-/**
- * selfservicedraft short summary.
- *
- * selfservicedraft description.
- *
- * @version 1.0
- * @author morono
- */
-class PluginProcessmakerSelfservicedraft extends CommonDBTM {
+class PluginProcessmakerTaskalert extends CommonDBTM {
 
 }

--- a/inc/taskrecall.class.php
+++ b/inc/taskrecall.class.php
@@ -2,7 +2,7 @@
 /*
 -------------------------------------------------------------------------
 ProcessMaker plugin for GLPI
-Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
+Copyright (C) 2014-2022 by Raynet SAS a company of A.Raymond Network.
 
 https://www.araymond.com/
 -------------------------------------------------------------------------
@@ -25,14 +25,6 @@ You should have received a copy of the GNU General Public License
 along with this plugin. If not, see <http://www.gnu.org/licenses/>.
 --------------------------------------------------------------------------
  */
-/**
- * selfservicedraft short summary.
- *
- * selfservicedraft description.
- *
- * @version 1.0
- * @author morono
- */
-class PluginProcessmakerSelfservicedraft extends CommonDBTM {
+class PluginProcessmakerTaskrecall extends CommonDBTM {
 
 }

--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -2,7 +2,7 @@
 /*
 -------------------------------------------------------------------------
 ProcessMaker plugin for GLPI
-Copyright (C) 2014-2023 by Raynet SAS a company of A.Raymond Network.
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
 
 https://www.araymond.com/
 -------------------------------------------------------------------------

--- a/install/install.php
+++ b/install/install.php
@@ -2,7 +2,7 @@
 /*
 -------------------------------------------------------------------------
 ProcessMaker plugin for GLPI
-Copyright (C) 2014-2023 by Raynet SAS a company of A.Raymond Network.
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
 
 https://www.araymond.com/
 -------------------------------------------------------------------------
@@ -34,23 +34,23 @@ function processmaker_install() {
    $config = Config::getConfigurationValues('plugin:processmaker');
 
    $config += [
-      'pm_server_URL'              => 'http://localhost/',
-      'pm_workspace'               => 'workflow',
-      'pm_admin_user'              => 'NULL',
-      'pm_admin_passwd'            => 'NULL',
-      'pm_theme'                   => 'glpi_classic',
-      'date_mod'                   => $_SESSION["glpi_currenttime"],
-      'taskcategories_id'          => 'NULL',
-      'users_id'                   => 'NULL',
-      'pm_group_guid'              => 'NULL',
-      'pm_dbserver_name'           => 'NULL',
-      'pm_dbname'                  => 'wf_workflow',
-      'pm_dbserver_user'           => 'NULL',
-      'pm_dbserver_passwd'         => 'NULL',
-      'maintenance'                => 0,
-      'ssl_verify'                 => 0,
-      'db_version'                 => '4.4.0',
-      'max_cases_per_item'         => 0,
+      'pm_server_URL'               => 'http://localhost/',
+      'pm_workspace'                => 'workflow',
+      'pm_admin_user'               => 'NULL',
+      'pm_admin_passwd'             => 'NULL',
+      'pm_theme'                    => 'glpi_classic',
+      'date_mod'                    => $_SESSION["glpi_currenttime"],
+      'taskcategories_id'           => 'NULL',
+      'users_id'                    => 'NULL',
+      'pm_group_guid'               => 'NULL',
+      'pm_dbserver_name'            => 'NULL',
+      'pm_dbname'                   => 'wf_workflow',
+      'pm_dbserver_user'            => 'NULL',
+      'pm_dbserver_passwd'          => 'NULL',
+      'maintenance'                 => 0,
+      'ssl_verify'                  => 0,
+      'db_version'                  => '4.6.0',
+      'max_cases_per_item'          => 0,
       'is_reassignreason_mandatory' => 0
       ];
 

--- a/install/mysql/processmaker-empty.sql
+++ b/install/mysql/processmaker-empty.sql
@@ -93,6 +93,7 @@ CREATE TABLE IF NOT EXISTS `glpi_plugin_processmaker_processes` (
 	`maintenance` TINYINT(1) NOT NULL DEFAULT '0',
    `max_cases_per_item` INT UNSIGNED NOT NULL DEFAULT '0',
 	`is_reassignreason_mandatory` TINYINT(1) NOT NULL DEFAULT '-2',
+	`plugin_processmaker_processcategories_id` INT UNSIGNED NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `process_guid` (`process_guid`)
 ) ENGINE=InnoDB;
@@ -116,18 +117,46 @@ CREATE TABLE `glpi_plugin_processmaker_processes_profiles` (
 
 -- Dumping structure for table glpi.glpi_plugin_processmaker_taskcategories
 CREATE TABLE `glpi_plugin_processmaker_taskcategories` (
+  `id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
+  `plugin_processmaker_processes_id` INT UNSIGNED NOT NULL,
+  `pm_task_guid` VARCHAR(32) NOT NULL,
+  `taskcategories_id` INT UNSIGNED NOT NULL,
+  `is_start` TINYINT(1) NOT NULL DEFAULT '0',
+  `is_active` TINYINT(1) NOT NULL DEFAULT '1',
+  `is_subprocess` TINYINT(1) NOT NULL DEFAULT '0',
+  `is_reassignreason_mandatory` TINYINT(1) NOT NULL DEFAULT '-2',
+  `before_time` INT NOT NULL DEFAULT '-10',
+  `after_time` INT NOT NULL DEFAULT '-10',
+  `users_id` INT UNSIGNED NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE INDEX `pm_task_guid` (`pm_task_guid`),
+  UNIQUE INDEX `taskcategories_id` (`taskcategories_id`),
+  INDEX `plugin_processmaker_processes_id` (`plugin_processmaker_processes_id`)
+) ENGINE=InnoDB;
+
+
+-- Dumping structure for table glpi.glpi_plugin_processmaker_taskrecalls
+CREATE TABLE `glpi_plugin_processmaker_taskrecalls` (
 	`id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
-	`plugin_processmaker_processes_id` INT UNSIGNED NOT NULL,
-	`pm_task_guid` VARCHAR(32) NOT NULL,
-	`taskcategories_id` INT UNSIGNED NOT NULL,
-	`is_start` TINYINT(1) NOT NULL DEFAULT '0',
-	`is_active` TINYINT(1) NOT NULL DEFAULT '1',
-	`is_subprocess` TINYINT(1) NOT NULL DEFAULT '0',
-	`is_reassignreason_mandatory` TINYINT(1) NOT NULL DEFAULT '-2',
+	`plugin_processmaker_tasks_id` INT UNSIGNED NOT NULL,
+	`before_time` INT NOT NULL DEFAULT '-10',
+	`after_time` INT NOT NULL DEFAULT '-10',
+	`when` TIMESTAMP NULL DEFAULT NULL,
+	`users_id` INT UNSIGNED NULL,
 	PRIMARY KEY (`id`),
-	UNIQUE INDEX `pm_task_guid` (`pm_task_guid`),
-	UNIQUE INDEX `items` (`taskcategories_id`),
-	INDEX `plugin_processmaker_processes_id` (`plugin_processmaker_processes_id`)
+	UNIQUE INDEX `item` (`plugin_processmaker_tasks_id`),
+	INDEX `when` (`when`)
+) ENGINE=InnoDB;
+
+
+-- Dumping structure for table glpi.glpi_plugin_processmaker_taskalerts
+CREATE TABLE `glpi_plugin_processmaker_taskalerts` (
+	`id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
+	`plugin_processmaker_taskrecalls_id` INT UNSIGNED NOT NULL DEFAULT '0',
+	`date` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	PRIMARY KEY (`id`),
+	INDEX `plugin_processmaker_taskrecalls_id` (`plugin_processmaker_taskrecalls_id`),
+	INDEX `date` (`date`)
 ) ENGINE=InnoDB;
 
 
@@ -187,6 +216,14 @@ CREATE TABLE IF NOT EXISTS `glpi_plugin_processmaker_reassignreasontranslations`
 	INDEX `plugin_processmaker_taskcategories_id` (`plugin_processmaker_taskcategories_id`)
 ) ENGINE=InnoDB;
 
+-- Dumping structure for table glpi.glpi_plugin_processmaker_processcategories
+CREATE TABLE `glpi_plugin_processmaker_processcategories` (
+	`id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
+	`name` VARCHAR(250) NOT NULL DEFAULT '',
+	`category_guid` VARCHAR(32) NULL,
+	PRIMARY KEY (`id`),
+	UNIQUE INDEX `category_guid` (`category_guid`)
+) ENGINE=InnoDB; 
 
 /*!40101 SET SQL_MODE=IFNULL(@OLD_SQL_MODE, '') */;
 /*!40014 SET FOREIGN_KEY_CHECKS=IF(@OLD_FOREIGN_KEY_CHECKS IS NULL, 1, @OLD_FOREIGN_KEY_CHECKS) */;

--- a/install/update.php
+++ b/install/update.php
@@ -2,7 +2,7 @@
 /*
 -------------------------------------------------------------------------
 ProcessMaker plugin for GLPI
-Copyright (C) 2014-2023 by Raynet SAS a company of A.Raymond Network.
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
 
 https://www.araymond.com/
 -------------------------------------------------------------------------
@@ -105,6 +105,15 @@ function processmaker_update() {
          // will upgrade 4.0.2 to 4.4.0
          include_once(PLUGIN_PROCESSMAKER_ROOT . "/install/update_4_0_2_to_4_4_0.php");
          $new_version = update_4_0_2_to_4_4_0();
+
+       case '4.4.0' :
+         // will upgrade 4.4.0 to 4.5.0
+         include_once(PLUGIN_PROCESSMAKER_ROOT . "/install/update_4_4_0_to_4_5_0.php");
+         $new_version = update_4_4_0_to_4_5_0();
+      case '4.5.0' :
+         // will upgrade 4.5.0 to 4.6.0
+         include_once(PLUGIN_PROCESSMAKER_ROOT . "/install/update_4_5_0_to_4_6_0.php");
+         $new_version = update_4_5_0_to_4_6_0();
 
    }
 

--- a/install/update_3_2_8_to_3_2_9.php
+++ b/install/update_3_2_8_to_3_2_9.php
@@ -2,7 +2,7 @@
 /*
 -------------------------------------------------------------------------
 ProcessMaker plugin for GLPI
-Copyright (C) 2014-2023 by Raynet SAS a company of A.Raymond Network.
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
 
 https://www.araymond.com/
 -------------------------------------------------------------------------

--- a/install/update_3_2_9_to_3_3_0.php
+++ b/install/update_3_2_9_to_3_3_0.php
@@ -2,7 +2,7 @@
 /*
 -------------------------------------------------------------------------
 ProcessMaker plugin for GLPI
-Copyright (C) 2014-2023 by Raynet SAS a company of A.Raymond Network.
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
 
 https://www.araymond.com/
 -------------------------------------------------------------------------

--- a/install/update_3_3_0_to_3_3_1.php
+++ b/install/update_3_3_0_to_3_3_1.php
@@ -2,7 +2,7 @@
 /*
 -------------------------------------------------------------------------
 ProcessMaker plugin for GLPI
-Copyright (C) 2014-2023 by Raynet SAS a company of A.Raymond Network.
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
 
 https://www.araymond.com/
 -------------------------------------------------------------------------

--- a/install/update_3_3_1_to_3_3_8.php
+++ b/install/update_3_3_1_to_3_3_8.php
@@ -2,7 +2,7 @@
 /*
 -------------------------------------------------------------------------
 ProcessMaker plugin for GLPI
-Copyright (C) 2014-2023 by Raynet SAS a company of A.Raymond Network.
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
 
 https://www.araymond.com/
 -------------------------------------------------------------------------

--- a/install/update_3_3_8_to_3_4_9.php
+++ b/install/update_3_3_8_to_3_4_9.php
@@ -2,7 +2,7 @@
 /*
 -------------------------------------------------------------------------
 ProcessMaker plugin for GLPI
-Copyright (C) 2014-2023 by Raynet SAS a company of A.Raymond Network.
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
 
 https://www.araymond.com/
 -------------------------------------------------------------------------

--- a/install/update_3_4_10_to_4_0_0.php
+++ b/install/update_3_4_10_to_4_0_0.php
@@ -2,7 +2,7 @@
 /*
 -------------------------------------------------------------------------
 ProcessMaker plugin for GLPI
-Copyright (C) 2014-2023 by Raynet SAS a company of A.Raymond Network.
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
 
 https://www.araymond.com/
 -------------------------------------------------------------------------

--- a/install/update_3_4_9_to_3_4_10.php
+++ b/install/update_3_4_9_to_3_4_10.php
@@ -2,7 +2,7 @@
 /*
 -------------------------------------------------------------------------
 ProcessMaker plugin for GLPI
-Copyright (C) 2014-2023 by Raynet SAS a company of A.Raymond Network.
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
 
 https://www.araymond.com/
 -------------------------------------------------------------------------

--- a/install/update_4_0_0_to_4_0_1.php
+++ b/install/update_4_0_0_to_4_0_1.php
@@ -2,7 +2,7 @@
 /*
 -------------------------------------------------------------------------
 ProcessMaker plugin for GLPI
-Copyright (C) 2014-2023 by Raynet SAS a company of A.Raymond Network.
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
 
 https://www.araymond.com/
 -------------------------------------------------------------------------
@@ -43,7 +43,7 @@ function update_4_0_0_to_4_0_1() {
       UNIQUE INDEX `guid_version` (`guid`, `version`),
       INDEX `plugin_processmaker_cases_id` (`plugin_processmaker_cases_id`),
       INDEX `is_output` (`is_output`)
-      ) ENGINE=InnoDB DEFAULT;";
+      ) ENGINE=InnoDB;";
    $DB->query($query) or die("error when creating glpi_plugin_processmaker_documents table" . $DB->error());
 
    $query = "ALTER TABLE `glpi_plugin_processmaker_crontaskactions`

--- a/install/update_4_0_1_to_4_0_2.php
+++ b/install/update_4_0_1_to_4_0_2.php
@@ -2,7 +2,7 @@
 /*
 -------------------------------------------------------------------------
 ProcessMaker plugin for GLPI
-Copyright (C) 2014-2023 by Raynet SAS a company of A.Raymond Network.
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
 
 https://www.araymond.com/
 -------------------------------------------------------------------------

--- a/install/update_4_0_2_to_4_4_0.php
+++ b/install/update_4_0_2_to_4_4_0.php
@@ -2,7 +2,7 @@
 /*
 -------------------------------------------------------------------------
 ProcessMaker plugin for GLPI
-Copyright (C) 2014-2023 by Raynet SAS a company of A.Raymond Network.
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
 
 https://www.araymond.com/
 -------------------------------------------------------------------------

--- a/install/update_4_4_0_to_4_5_0.php
+++ b/install/update_4_4_0_to_4_5_0.php
@@ -1,0 +1,71 @@
+<?php
+/*
+-------------------------------------------------------------------------
+ProcessMaker plugin for GLPI
+Copyright (C) 2014-2023 by Raynet SAS a company of A.Raymond Network.
+
+https://www.araymond.com/
+-------------------------------------------------------------------------
+
+LICENSE
+
+This file is part of ProcessMaker plugin for GLPI.
+
+This file is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This plugin is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this plugin. If not, see <http://www.gnu.org/licenses/>.
+--------------------------------------------------------------------------
+ */
+function update_4_4_0_to_4_5_0() {
+    global $DB;
+
+    if (!$DB->tableExists('glpi_plugin_processmaker_taskrecalls')) {
+        $query  = "CREATE TABLE `glpi_plugin_processmaker_taskrecalls` (
+             `id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
+             `plugin_processmaker_tasks_id` INT UNSIGNED NOT NULL,
+             `before_time` INT NOT NULL DEFAULT '-10',
+             `after_time` INT NOT NULL DEFAULT '-10',
+             `when` TIMESTAMP NULL DEFAULT NULL,
+             `users_id` INT UNSIGNED NULL,
+             PRIMARY KEY (`id`),
+             UNIQUE INDEX `item` (`plugin_processmaker_tasks_id`),
+             INDEX `when` (`when`)
+           ) ENGINE=InnoDB;";
+        $DB->query($query) or die("error when creating glpi_plugin_processmaker_taskrecalls table" . $DB->error());
+    }
+
+    if (!$DB->tableExists('glpi_plugin_processmaker_taskalerts')) {
+        $query = "CREATE TABLE `glpi_plugin_processmaker_taskalerts` (
+            `id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
+            `plugin_processmaker_taskrecalls_id` INT UNSIGNED NOT NULL,
+            `date` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY (`id`),
+            INDEX `plugin_processmaker_taskrecalls_id` (`plugin_processmaker_taskrecalls_id`),
+            INDEX `date` (`date`)
+            ) ENGINE=InnoDB;";
+
+        $DB->query($query) or die("error when creating glpi_plugin_processmaker_taskalerts table" . $DB->error());
+    }
+
+    if (!$DB->fieldExists('glpi_plugin_processmaker_taskcategories', 'reminder_recall_time')) {
+        // add the field into table
+        $query = "ALTER TABLE `glpi_plugin_processmaker_taskcategories`
+                  ADD COLUMN `before_time` INT NOT NULL DEFAULT '-10',
+                  ADD COLUMN `after_time` INT NOT NULL DEFAULT '-10',
+                  ADD COLUMN `users_id` INT UNSIGNED NULL
+                  ;";
+
+        $DB->query($query) or die("error when adding reminder_recall_time field to glpi_plugin_processmaker_taskcategories table" . $DB->error());
+    }
+
+   return '4.5.0';
+}

--- a/install/update_4_5_0_to_4_6_0.php
+++ b/install/update_4_5_0_to_4_6_0.php
@@ -25,14 +25,26 @@ You should have received a copy of the GNU General Public License
 along with this plugin. If not, see <http://www.gnu.org/licenses/>.
 --------------------------------------------------------------------------
  */
-/**
- * selfservicedraft short summary.
- *
- * selfservicedraft description.
- *
- * @version 1.0
- * @author morono
- */
-class PluginProcessmakerSelfservicedraft extends CommonDBTM {
+function update_4_5_0_to_4_6_0() {
+   global $DB;
 
+   if (!$DB->tableExists('glpi_plugin_processmaker_processcategories')) {
+        $query = "CREATE TABLE `glpi_plugin_processmaker_processcategories` (
+					`id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
+					`name` VARCHAR(250) NOT NULL DEFAULT '',
+					`category_guid` VARCHAR(32) NULL,
+					PRIMARY KEY (`id`),
+					UNIQUE INDEX `category_guid` (`category_guid`)
+					);";
+
+       $DB->query($query) or die("error when creating glpi_plugin_processmaker_processcategories table" . $DB->error());
+   }
+    if (!$DB->fieldExists('glpi_plugin_processmaker_processes', 'plugin_processmaker_processcategories_id')) {
+        $query = "ALTER TABLE `glpi_plugin_processmaker_processes`
+					ADD COLUMN `plugin_processmaker_processcategories_id` INT UNSIGNED NULL AFTER `is_reassignreason_mandatory`;
+					";
+
+       $DB->query($query) or die("error when creating glpi_plugin_processmaker_processcategories table" . $DB->error());
+    }
+   return '4.6.0';
 }

--- a/install/update_to_3_2_8.php
+++ b/install/update_to_3_2_8.php
@@ -2,7 +2,7 @@
 /*
 -------------------------------------------------------------------------
 ProcessMaker plugin for GLPI
-Copyright (C) 2014-2023 by Raynet SAS a company of A.Raymond Network.
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
 
 https://www.araymond.com/
 -------------------------------------------------------------------------

--- a/js/cases.js
+++ b/js/cases.js
@@ -1,7 +1,7 @@
 ﻿/*
 -------------------------------------------------------------------------
 ProcessMaker plugin for GLPI
-Copyright (C) 2014-2023 by Raynet SAS a company of A.Raymond Network.
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
 
 https://www.araymond.com/
 -------------------------------------------------------------------------

--- a/js/central.js
+++ b/js/central.js
@@ -1,7 +1,7 @@
 /*
 -------------------------------------------------------------------------
 ProcessMaker plugin for GLPI
-Copyright (C) 2014-2023 by Raynet SAS a company of A.Raymond Network.
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
 
 https://www.araymond.com/
 -------------------------------------------------------------------------

--- a/js/helpdesk.public.js.php
+++ b/js/helpdesk.public.js.php
@@ -2,7 +2,7 @@
 /*
 -------------------------------------------------------------------------
 ProcessMaker plugin for GLPI
-Copyright (C) 2014-2023 by Raynet SAS a company of A.Raymond Network.
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
 
 https://www.araymond.com/
 -------------------------------------------------------------------------

--- a/js/planning.js
+++ b/js/planning.js
@@ -1,7 +1,7 @@
 ﻿/*
 -------------------------------------------------------------------------
 ProcessMaker plugin for GLPI
-Copyright (C) 2014-2023 by Raynet SAS a company of A.Raymond Network.
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
 
 https://www.araymond.com/
 -------------------------------------------------------------------------

--- a/js/processmaker_icon.js
+++ b/js/processmaker_icon.js
@@ -1,7 +1,7 @@
 /*
 -------------------------------------------------------------------------
 ProcessMaker plugin for GLPI
-Copyright (C) 2014-2023 by Raynet SAS a company of A.Raymond Network.
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
 
 https://www.araymond.com/
 -------------------------------------------------------------------------

--- a/processmaker.xml
+++ b/processmaker.xml
@@ -41,11 +41,11 @@
          <compatibility>9.4</compatibility>
       </version>
       <version>
-         <num>4.4.1</num>
+         <num>4.7.2</num>
          <compatibility>9.5</compatibility>
       </version>
       <version>
-         <num>5.0.3</num>
+         <num>5.2.3</num>
          <compatibility>10.0</compatibility>
       </version>
    </versions>

--- a/scripts/caseDump.php
+++ b/scripts/caseDump.php
@@ -1,4 +1,31 @@
 <?php
+/*
+-------------------------------------------------------------------------
+ProcessMaker plugin for GLPI
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
+
+https://www.araymond.com/
+-------------------------------------------------------------------------
+
+LICENSE
+
+This file is part of ProcessMaker plugin for GLPI.
+
+This file is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This plugin is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this plugin. If not, see <http://www.gnu.org/licenses/>.
+--------------------------------------------------------------------------
+ */
+
 // to dump case records, to be able to restore case state
 
 // Ensure current directory when run from crontab

--- a/scripts/caseRestore.php
+++ b/scripts/caseRestore.php
@@ -1,4 +1,30 @@
 <?php
+/*
+-------------------------------------------------------------------------
+ProcessMaker plugin for GLPI
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
+
+https://www.araymond.com/
+-------------------------------------------------------------------------
+
+LICENSE
+
+This file is part of ProcessMaker plugin for GLPI.
+
+This file is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This plugin is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this plugin. If not, see <http://www.gnu.org/licenses/>.
+--------------------------------------------------------------------------
+ */
 
 // to restore case state
 

--- a/setup.php
+++ b/setup.php
@@ -2,7 +2,7 @@
 /*
  -------------------------------------------------------------------------
 ProcessMaker plugin for GLPI
-Copyright (C) 2014-2023 by Raynet SAS a company of A.Raymond Network.
+Copyright (C) 2014-2024 by Raynet SAS a company of A.Raymond Network.
 
 https://www.araymond.com/
 -------------------------------------------------------------------------
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License
 along with this plugin. If not, see <http://www.gnu.org/licenses/>.
 --------------------------------------------------------------------------
  */
-define('PROCESSMAKER_VERSION', '5.0.3');
+define('PROCESSMAKER_VERSION', '5.2.3');
 
 // Minimal GLPI version, inclusive
 define('PLUGIN_PROCESSMAKER_MIN_GLPI', '10.0');
@@ -33,7 +33,7 @@ define('PLUGIN_PROCESSMAKER_MIN_GLPI', '10.0');
 define('PLUGIN_PROCESSMAKER_MAX_GLPI', '10.1');
 
 // Minimal PM version, inclusive
-define('PLUGIN_PROCESSMAKER_MIN_PM', '3.3.0-community-RE-2.0');
+define('PLUGIN_PROCESSMAKER_MIN_PM', '3.3.0-community-RE-2.8');
 // Maximum PM version, inclusive
 define('PLUGIN_PROCESSMAKER_MAX_PM', '3.3.0-community-RE-2.99');
 
@@ -63,6 +63,7 @@ function plugin_init_processmaker() {
       Plugin::registerClass('PluginProcessmakerTask', ['notificationtemplates_types' => true]);
 
       Plugin::registerClass('PluginProcessmakerTaskCategory', ['addtabon' => 'TaskCategory']);
+      Plugin::registerClass('PluginProcessmakerProcessCategory');
 
       if (Session::haveRightsOr("config", [READ, UPDATE])) {
          Plugin::registerClass('PluginProcessmakerConfig', ['addtabon' => 'Config']);
@@ -77,6 +78,8 @@ function plugin_init_processmaker() {
 
       $PLUGIN_HOOKS['pre_show_item']['processmaker']
          = ['PluginProcessmakerProcessmaker', 'pre_show_item_processmaker'];
+      $PLUGIN_HOOKS['post_show_item']['processmaker']
+         = ['PluginProcessmakerProcessmaker', 'post_show_item_processmaker'];
 
       $PLUGIN_HOOKS['pre_show_tab']['processmaker']
          = ['PluginProcessmakerProcessmaker', 'pre_show_tab_processmaker'];


### PR DESCRIPTION
* Bugfix Reminders on task cancelled before delete reminders update was not deleted
* Bugfix Uncaught ReferenceError: $ is not defined on ITIL Object creation
* Delete error message after case cancellation successfully
* change minimum version of processmaker server
* delete TODO comment
* Add possibility to cancel case with multiple tasks
* bugfix delete reminder on case's cancel  or delete
* Add behavior on a claimed task or reasign to the current user for show task in timeline
* Fixed issue with default dates settings in reminders for tasks
* Added shortcut to select "Me as sender"
* Added a test to prevent post-only user to set reminder settings
* Updated XML
* Fix issue with screen view
* Adjusted wordings
* Reviewed $new_date computation in cron
* Bugfix creating a case in processcase tab doesn't redirect to the case
* Adjusted visualization for Reminder
* Added an `<hr>`
* Adjusted values in dropdowns when settings are NULL
* Added a test to prevent sending of remminders to "ProcessMaker" user
* Added view of default and actual reminder settings for a PM task
* cronPMReminder reflects changes and send reminders
* Re-engineered table fields and search options
* Fixed issue with FUP that were no longuer added to timeline.
* Added automatic reminders
* bugfix on filter
* Changed copyrights
* added .gitignore
* add process category search option + input in process form
* Added process categories
* bugfixes on helpdesk process
* bugfixes html_tags and actiontime
* Changed the way the userId of the first task was computed, to be able to have a tobeclaimed task
* Added get/set APP_DATA scripts to be able to read/write the APP_DATA in json files
* Added a followup when a reminder is sent to task user (or group)

Set version 5.2.3